### PR TITLE
🔨 chore(collect-form): skip limits validation in sandbox environment

### DIFF
--- a/src/components/CollectForm/CollectForm.stories.jsx
+++ b/src/components/CollectForm/CollectForm.stories.jsx
@@ -58,7 +58,7 @@ export const Dev = () => (
 export const Sandbox = () => (
   <CollectForm
     environment="sandbox"
-    token=""
+    token="test-token"
     onSubmit={(id, httpStatus, httpResponse) => {
       // This will be called when the submit button is pressed.
       // It will be called even on errors

--- a/src/hooks/useLimitsValidation.js
+++ b/src/hooks/useLimitsValidation.js
@@ -30,6 +30,13 @@ const useLimitsValidation = ({ token, environment = 'dev' }) => {
       return
     }
 
+    // In sandbox environment, skip limits validation
+    if (environment === 'sandbox') {
+      setCanCreate(true)
+      setLoading(false)
+      return
+    }
+
     const fetchLimits = async () => {
       try {
         const config = getConfig(environment)


### PR DESCRIPTION
## Summary
Introduces an environment-aware check that bypasses limits validation in sandbox environments and updates related tests and stories accordingly.

## Key Changes
- chore(collect-form): Skip limits validation in sandbox environments
- test(collect-form, hooks): Update unit tests to cover sandbox behavior
- chore(stories): Adjust stories to reflect sandbox validation bypass

## Commits
- b95447a — Skip limits validation in sandbox environment (2025-10-29)

## Files changed (high-level)
- Added
  - (none)
- Renamed
  - (none)
- Removed
  - (none)
- Modified
  - src/components/CollectForm/CollectForm.stories.jsx
  - src/hooks/useLimitsValidation.js
  - src/test/CollectFormWrapper.test.jsx
  - src/test/useLimitsValidation.test.jsx

## BREAKING CHANGE
None. No public API or component path was renamed. Consumers do not need to update imports or usage.